### PR TITLE
Set flask port to 8022

### DIFF
--- a/app.py
+++ b/app.py
@@ -133,4 +133,4 @@ def sync_birthdays():
     return "OK"
 
 if __name__ == '__main__':
-    socketio.run(app, debug=True)
+    socketio.run(app, debug=True, port=8022)


### PR DESCRIPTION
## Summary
- change the port for `socketio.run` to 8022

## Testing
- `python -m py_compile app.py`
- `python app.py` (confirmed server starts on port 8022)

------
https://chatgpt.com/codex/tasks/task_e_68862fc1f7388321ae09282ebc8ba31a