### PR TITLE
Fix README and allow remote access

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,12 @@ Ein Flask-Webinterface, um Geburtstage aus deinen Google-Kontakten automatisch i
 git clone https://github.com/dein-benutzername/geburtstagsimporter.git
 cd geburtstagsimporter
 pip install -r requirements.txt
+```
+
+Starte das Webinterface anschließend mit:
+
+```bash
+python3 app.py
+```
+
+Die Anwendung ist dann unter `http://<SERVER-IP>:8022` erreichbar.

--- a/app.py
+++ b/app.py
@@ -133,4 +133,4 @@ def sync_birthdays():
     return "OK"
 
 if __name__ == '__main__':
-    socketio.run(app, debug=True, port=8022)
+    socketio.run(app, debug=True, port=8022, host="0.0.0.0")


### PR DESCRIPTION
## Summary
- host Flask app on `0.0.0.0` so it is reachable from other machines
- fix and extend README with clear run instructions

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688632b2b90c8321a0c52c053d9c2f89