### PR TITLE
Handle SIGINT for clean shutdown

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,8 @@ import os
 import datetime
 import pickle
 import logging
+import signal
+import sys
 from flask import Flask, render_template, jsonify, request
 from flask_socketio import SocketIO
 from google_auth_oauthlib.flow import InstalledAppFlow
@@ -29,6 +31,14 @@ def emit_status(msg):
     socketio.emit('status', msg)
     print(msg)
     logging.info(msg)
+
+def handle_sigint(sig, frame):
+    """Gracefully stop the server when CTRL-C is pressed."""
+    emit_status("Server wird beendet...")
+    socketio.stop()
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, handle_sigint)
 
 flow = None  # keep OAuth flow between requests
 


### PR DESCRIPTION
## Summary
- exit cleanly on `CTRL-C` by handling SIGINT

## Testing
- `python -m py_compile app.py`
- Started server with `python app.py` and verified it stops when pressing `CTRL-C`


------
https://chatgpt.com/codex/tasks/task_e_688640e06a588321877a6daba64501ca