### PR TITLE
Automatically export birthdays on sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,19 @@ Anmeldecode in das bereitgestellte Feld.
 
 Klicke anschließend im Browser auf **Jetzt synchronisieren**. Alle Statusmeldungen
 – inklusive der erfolgreich übertragenen Geburtstage – erscheinen live im Bereich
-"Log" auf der Webseite.
+"Log" auf der Webseite. Bei jeder Synchronisation wird außerdem automatisch eine
+Datei `Geburtstage.txt` erzeugt, die alle Geburtstage nach Datum sortiert enthält.
+
+## Geburtstage als Textdatei exportieren
+
+Falls du nur die Textdatei ohne Kalender-Sync benötigst, kannst du das
+Skript `export_birthdays.py` separat aufrufen:
+
+```bash
+python3 export_birthdays.py
+```
+
+Nach der OAuth‑Autorisierung erstellt das Skript – genau wie die
+Synchronisation – die Datei `Geburtstage.txt`, in der alle Geburtstage
+nach Datum sortiert gelistet sind. Jede Zeile enthält das Datum im
+Format `TT.MM.JJJJ` gefolgt vom Namen.

--- a/app.py
+++ b/app.py
@@ -110,6 +110,21 @@ def get_birthdays(people_service):
 
     return birthdays
 
+def write_birthdays_file(birthdays, filename="Geburtstage.txt"):
+    """Write sorted birthdays to a text file."""
+    birthdays = sorted(
+        birthdays,
+        key=lambda b: (b['date']['month'], b['date']['day'], b['date'].get('year', 0))
+    )
+
+    with open(filename, 'w') as f:
+        for b in birthdays:
+            d = b['date']
+            year = d.get('year', 2000)
+            dt = datetime.date(year, d['month'], d['day'])
+            f.write(f"{dt.strftime('%d.%m.%Y')} {b['name']}\n")
+    emit_status(f"✏️ {filename} geschrieben")
+
 def create_events(calendar_service, calendar_id, birthdays):
     emit_status("Prüfe vorhandene Geburtstage im Kalender...")
     existing_events = calendar_service.events().list(
@@ -179,6 +194,7 @@ def sync_birthdays():
         else:
             emit_status(f"❌ Fehler beim Abrufen der Kontakte: {e}")
         return "Error", 500
+    write_birthdays_file(birthdays)
     try:
         create_events(calendar_service, calendar_id, birthdays)
     except HttpError as e:

--- a/export_birthdays.py
+++ b/export_birthdays.py
@@ -1,0 +1,18 @@
+from app import get_services, get_birthdays, write_birthdays_file
+
+
+def export_to_file(filename: str = "Geburtstage.txt") -> None:
+    """Fetch birthdays from Google People API and write them sorted to a file."""
+    people_service, _, auth_url = get_services()
+    if auth_url:
+        print("Öffne den folgenden Link im Browser und autorisiere den Zugriff:")
+        print(auth_url)
+        code = input("Gib den angezeigten Code ein: ")
+        people_service, _, _ = get_services(auth_code=code)
+
+    birthdays = get_birthdays(people_service)
+    write_birthdays_file(birthdays, filename)
+
+
+if __name__ == "__main__":
+    export_to_file()


### PR DESCRIPTION
## Summary
- export birthdays directly from `app.py` on every sync
- reuse `write_birthdays_file` in `export_birthdays.py`
- document automatic export in README

## Testing
- `pip install -r requirements.txt`
- `python3 export_birthdays.py --help` *(fails: credentials.json missing)*
- `nl -ba Geburtstage.txt`


------
https://chatgpt.com/codex/tasks/task_e_688643d9533c83218074c5e556ea421e