### PR TITLE
Improve log output flushing

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,7 +29,8 @@ socketio = SocketIO(app)
 
 def emit_status(msg):
     socketio.emit('status', msg)
-    print(msg)
+    # Flush stdout so messages appear immediately
+    print(msg, flush=True)
     logging.info(msg)
 
 def handle_sigint(sig, frame):


### PR DESCRIPTION
## Summary
- flush stdout in `emit_status` so logs appear immediately

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68864c2b9ddc8321b5b9600bb5005639