### PR TITLE
Extend event import and show logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # 🎂 Google Geburtstagsimporter
 
-Ein Flask-Webinterface, um Geburtstage aus deinen Google-Kontakten automatisch in einen separaten Google Kalender ("Geburtstage") zu importieren – mit Web-GUI, Live-Statusanzeige und Dublettenprüfung.
+Ein Flask-Webinterface, um Geburtstage und andere datierte Ereignisse aus deinen Google-Kontakten automatisch in einen separaten Google Kalender ("Geburtstage") zu importieren – mit Web-GUI, Live-Statusanzeige und Dublettenprüfung.
 
 ## ✅ Features
 
-- Liest Geburtstage sowie weitere Ereignisse (z. B. Jahrestage) aus deinen Google Kontakten via People API
+- Liest Geburtstage **und alle anderen datierten Ereignisse** aus deinen Google Kontakten via People API
 - Erstellt oder nutzt den Kalender „Geburtstage“
-- Fügt nur **neue** Geburtstage ein (Vermeidung von Duplikaten)
+- Fügt nur **neue** Ereignisse ein (Vermeidung von Duplikaten)
 - Leert den Kalender vor jeder Synchronisierung
 - Webinterface mit Live-Statusanzeige (via Socket.IO)
 - Logging in `log.txt` mit Zeitstempeln
+- Logeinträge werden beim Laden der Webseite angezeigt
 - Lokale OAuth2-Autorisierung via `credentials.json`
 
 ## 🚀 Installation
@@ -40,5 +41,5 @@ Anmeldecode in das bereitgestellte Feld.
 
 Klicke anschließend im Browser auf **Jetzt synchronisieren**. Alle Statusmeldungen
 – inklusive der erfolgreich übertragenen Ereignisse – erscheinen live im Bereich
-"Log" auf der Webseite. Bei jeder Synchronisation wird außerdem automatisch eine
-Datei `Geburtstage.txt` erzeugt, die alle gefundenen Daten nach Datum sortiert enthält.
+"Log" auf der Webseite. Bei jeder Synchronisierung wird außerdem automatisch eine
+Datei `Geburtstage.txt` erzeugt, die alle gefundenen Ereignisse nach Datum sortiert enthält.

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,10 +16,22 @@
     <div id="log"></div>
 
     <script>
+        const logEl = document.getElementById('log');
+
         const socket = io();
         socket.on('status', msg => {
-            document.getElementById('log').innerText += msg + "\n";
+            logEl.innerText += msg + "\n";
+            logEl.scrollTop = logEl.scrollHeight;
         });
+
+        async function loadLog() {
+            const resp = await fetch('/logs');
+            if (resp.ok) {
+                logEl.innerText = await resp.text();
+                logEl.scrollTop = logEl.scrollHeight;
+            }
+        }
+        loadLog();
 
         async function startSync() {
             const resp = await fetch('/sync');


### PR DESCRIPTION
## Summary
- import all contact events instead of only birthdays and anniversaries
- write events to `Geburtstage.txt` with labels
- expose `/logs` endpoint and show the log on page load
- adjust calendar event creation for generic events
- update README to document new behavior

## Testing
- `pip install -q -r requirements.txt`
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68864e90ff4083218ec833233cccf03c