### PR TITLE
AdSense-Skript in Head-Bereiche aller Templates einfügen

### DIFF
--- a/templates/datenschutz.html
+++ b/templates/datenschutz.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>Datenschutzerklärung</title>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9376188585752918"
+            crossorigin="anonymous"></script>
     <style>
         body {
             font-family: Arial, sans-serif;

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>Google Geburtstagsimport</title>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9376188585752918"
+            crossorigin="anonymous"></script>
     <script src="{{ url_for('static', filename='socket.io.min.js') }}"></script>
     <style>
         body {

--- a/templates/nutzungsbedingungen.html
+++ b/templates/nutzungsbedingungen.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>Nutzungsbedingungen</title>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9376188585752918"
+            crossorigin="anonymous"></script>
     <style>
         body {
             font-family: Arial, sans-serif;


### PR DESCRIPTION
### Motivation
- Die Seiten sollen das Google AdSense-Skript laden, damit Anzeigen ausgeliefert werden können, indem das Skript in den `<head>`-Bereich aller relevanten HTML-Templates eingefügt wird.

### Description
- In `templates/index.html` wurde das AdSense-Skript mit `client=ca-pub-9376188585752918` unmittelbar nach dem `<title>` in den `<head>` eingefügt.
- Dasselbe Skript wurde in `templates/datenschutz.html` und in `templates/nutzungsbedingungen.html` jeweils in den `<head>` integriert.
- Das eingefügte Tag verwendet `async` und `crossorigin="anonymous"` entsprechend der Vorgabe.

### Testing
- `python -m pytest -q` berichtete „no tests ran“, da das Projekt keine Testfälle enthält.
- `python -m py_compile app.py` wurde erfolgreich ausgeführt und meldete keine Syntaxfehler.
- Ein kurzes Python-Validierungsskript prüfte, dass das Skript in jeder der drei Templates genau einmal und innerhalb des `<head>` vorhanden ist und gab einen erfolgreichen Status zurück.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d87074004832180d7023ff3d4332a)